### PR TITLE
Removes \n \r in field labels

### DIFF
--- a/MonitoringQRModule.php
+++ b/MonitoringQRModule.php
@@ -908,8 +908,9 @@ function addHistoryButton(showHistory) {
 
             //strip any markup to allow this to succeed
             //fix for #112. replace any " or ' in the label. This means the history won't show the exact label as these chars
+            // replace any carriage returns or new lines with space in the label. This means the history won't show the exact label as these chars
             //will be removed, but better than bombing out and the solution is tricky
-            $fieldDataCleaned = str_replace('"', '', str_replace("'", "", (strip_tags($formInfo["formInfo"][$field]["fieldLabel"]))));
+            $fieldDataCleaned = str_replace(array("\r", "\n"), ' ', str_replace(array("'", '"'), "", (strip_tags($formInfo["formInfo"][$field]["fieldLabel"]))));
             $queryData[] = ["field" => $field, "field_label" => $fieldDataCleaned, "flags" => $flagsStr];
         }
 


### PR DESCRIPTION
Replaced \n and \r with space and " and ' with no space in field label
<img width="803" height="159" alt="Screenshot 2025-10-02 at 13 48 26" src="https://github.com/user-attachments/assets/c12bdc82-a1f1-4711-ae17-2fb613690087" />

<img width="803" height="165" alt="Screenshot 2025-10-02 at 13 48 35" src="https://github.com/user-attachments/assets/4d2cadd5-6f3e-4c2b-83e8-827fbf38de78" />
